### PR TITLE
nix-webapps-lib.mkChromiumApp: switch to makeShellWrapper

### DIFF
--- a/imports/lib.nix
+++ b/imports/lib.nix
@@ -14,7 +14,7 @@
               buildInputs = [ prev.chromium ];
 
               nativeBuildInputs = [
-                prev.makeBinaryWrapper
+                prev.makeShellWrapper
                 prev.copyDesktopItems
               ];
 


### PR DESCRIPTION
The binary wrapper does not expand `$XDG_CONIFG_HOME` in the `--user-data-dir` argument, resulting in a directory literally named `$XDG_CONFIG_HOME` being created in the user's home directory.